### PR TITLE
Let the host app own the pdf.js worker instead of loading it from unpkg

### DIFF
--- a/src/components/PdfViewer/PdfViewer.tsx
+++ b/src/components/PdfViewer/PdfViewer.tsx
@@ -17,7 +17,29 @@ import { useRotation } from "./useRotation";
 import { usePageManagement } from "./usePageManagement";
 import { usePanning } from "./usePanning";
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+// The pdf.js worker is deliberately NOT configured here. `react-pdf` is external
+// to this bundle, so the host app owns the single pdfjs-dist instance and is the
+// only place that can emit the worker as a same-origin asset — a library built in
+// Vite lib mode can only inline it (~1.4 MB), which every consumer would pay for
+// on load whether or not a PDF is ever opened.
+//
+// Host apps MUST set `pdfjs.GlobalWorkerOptions.workerSrc` once at startup, e.g.
+//   import { pdfjs } from "react-pdf";
+//   pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+//     "pdfjs-dist/build/pdf.worker.min.mjs",
+//     import.meta.url,
+//   ).toString();
+// Pointing it at a public CDN is not acceptable: crew run on filtered/degraded
+// satellite links where that fetch is the one most likely to fail.
+if (
+  process.env.NODE_ENV !== "production" &&
+  !pdfjs.GlobalWorkerOptions.workerSrc
+) {
+  console.warn(
+    "[shipping-ui] PdfViewer: pdfjs.GlobalWorkerOptions.workerSrc is not set. " +
+      "Configure it once in the host app or PDFs will fail to render.",
+  );
+}
 
 type PdfViewerProps = React.HTMLProps<HTMLDivElement> & {
   onClose: () => void;


### PR DESCRIPTION
`PdfViewer` set `pdfjs.GlobalWorkerOptions.workerSrc` to `//unpkg.com/pdfjs-dist@<version>/build/pdf.worker.min.mjs` at module scope, so opening a PDF depended on a public CDN being reachable. Our users are crew on filtered/degraded satellite links — that fetch is the one most likely to fail, and when it does the viewer simply never renders.

This removes the assignment and makes worker configuration the host app's job.

## Why the library can't just self-host it

`react-pdf` is already `external` here, so the host app owns the single `pdfjs-dist` instance — it is the only place that can emit the worker as a same-origin asset.

Resolving it inside the library was measured and rejected. Vite **always inlines assets in lib mode** (`assetsInlineLimit: 0` makes no difference — verified), so `new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url)` here inlines the worker as a `data:` URL:

| | dist/index.esm.js | gzip |
|---|---|---|
| before | 1,443.04 kB | 742.42 kB |
| worker inlined | 2,823.08 kB | 1,185.14 kB |

That is **+1,380 kB raw / +443 kB gzipped on every page load**, whether or not a PDF is ever opened — strictly worse for the satellite-link users this was meant to help. (`data:` URL workers also have unverified CSP/Safari exposure.)

## What host apps must do

Set it once at startup:

```ts
import { pdfjs } from "react-pdf";

pdfjs.GlobalWorkerOptions.workerSrc = new URL(
  "pdfjs-dist/build/pdf.worker.min.mjs",
  import.meta.url,
).toString();
```

In an app (not lib) build Vite emits that as a content-hashed, same-origin, lazily-fetched asset, and because the app owns the single `pdfjs-dist` the worker cannot drift from the API version.

A dev-only `console.warn` fires if `workerSrc` is unset when `PdfViewer` is used, so a host app that forgets gets told rather than silently shipping a broken viewer.

## Notes

- Bundle size is unchanged (+0.14 kB for the warning); no CDN reference survives in `dist/` (`grep -c unpkg.com dist/index.esm.js dist/index.cjs` → 0, 0).
- No story renders `PdfViewer`, so Storybook is unaffected.
- **Coordination:** the consuming frontend must set `workerSrc` in the same change that picks up this release, or PDFs will stop rendering there. The matching frontend PR does both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)